### PR TITLE
Handle multiple video types

### DIFF
--- a/README
+++ b/README
@@ -9,6 +9,9 @@ If you install this plugin manually, make sure it is installed in
 lib/plugins/html5video/ - if the folder is called different it
 will not work!
 
+Example :
+{{ videos:vid.webm|videos:vid.ogv|videos:vid.mp4|320x240|loop }}
+
 Please refer to http://www.dokuwiki.org/plugins for additional info
 on how to install plugins in DokuWiki.
 

--- a/TODO
+++ b/TODO
@@ -1,3 +1,5 @@
-* Allow for graceful fallback to other web video formats for different browsers
+* Allow for graceful fallback to other web video formats for different browsers - DONE 2014/01/16
+
+* Handle type in source element
 
 * Might be a good idea to use a stylesheet instead of inline styles for alignment

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   html5video
-author Jason van Gumster (Fweeb)
-email  jason@monsterjavaguns.com
-date   2013-03-07
+author Jason van Gumster (Fweeb) & Maxime Morel
+email  jason@monsterjavaguns.com & maxime.morel69@gmail.com
+date   2014-01-16
 name   html5video plugin
 desc   Embeds video using HTML5 syntax
 url    http://www.dokuwiki.org/plugin:html5video

--- a/syntax/video.php
+++ b/syntax/video.php
@@ -102,17 +102,31 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
             $align = "";
         }
 
+        $video_url_types = array(); // video url types array
         $nb = count($video_urls);
         for($i=0; $i<$nb; ++$i) {
             if(!substr_count($video_urls[$i], '/')) {
                 $video_urls[$i] = ml($video_urls[$i]);
             }
 
-            if(substr($video_urls[$i], -4) != 'webm' && substr($video_urls[$i], -3) != 'ogv' && substr($video_urls[$i], -3) != 'mp4') {
+            if(substr($video_urls[$i], -4) == 'webm') {
+                $video_url_types[$i] = "video/webm";
+            }
+            else if(substr($video_urls[$i], -3) == 'ogv') {
+                $video_url_types[$i] = "video/ogg";
+            }
+            else if(substr($video_urls[$i], -3) == 'mp4') {
+                $video_url_types[$i] = "video/mp4";
+            }
+            else {
                 $renderer->doc .= "Error: The video must be in webm, ogv, or mp4 format.<br />" . $video_urls[$i];
                 return false;
             }
         }
+
+        /*for($i=0; $i<$nb; ++$i) {
+            $renderer->doc .= $video_urls[$i] . " -> " . $video_url_types[$i] ."<br />";
+        }*/
 
         if(is_null($video_size) or !substr_count($video_size, 'x')) {
             $width  = 640;
@@ -154,9 +168,8 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
 
         $obj = '<video width="' . $width . '" height="' . $height . '" controls="controls" ' . $attr . '>';
         for($i=0; $i<$nb; ++$i) {
-            $obj .= '<source src="' . $video_urls[$i] . '">';
+            $obj .= '<source src="' . $video_urls[$i] . '" type="' . $video_url_types[$i] . '">';
         }
-        // TODO : handle types : type="video/webm" type="video/ogg" type="video/mp4"
         $obj .= '</video>';
 
         if($align != "") {

--- a/syntax/video.php
+++ b/syntax/video.php
@@ -70,7 +70,6 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
         if($mode != 'xhtml') return false;
 
         list($state, $params) = $data;
-        //list($video_align, $video_url, $video_size, $video_attr) = $params;
 
         $video_align = $params[0];
 
@@ -79,9 +78,7 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
         // find video url and parameters
         $nb = count($params);
         for($i=1; $i<$nb; ++$i) {
-            //$renderer->doc .= "params[".$i."] = ".$params[$i]."<br />";
             if(preg_match("((^.*\.mp4$)|(^.*\.ogv$)|(^.*\.webm$))", $params[$i]) == 1) {
-                //$renderer->doc .= "is video<br />";
                 $video_urls[] = $params[$i];
             }
             else {
@@ -91,17 +88,6 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
 
         $video_size = $params[$i];
         $video_attr = $params[$i+1];
-
-
-        /*foreach ($video_urls as $video_url) {
-            $renderer->doc .= "video_url : ".$video_url."<br />";
-        }*/
-
-        /*$renderer->doc .= "state : ".$state."<br />";
-        $renderer->doc .= "video_align : ".$video_align."<br />";
-        $renderer->doc .= "video_url : ".$video_url."<br />";
-        $renderer->doc .= "video_size : ".$video_size."<br />";
-        $renderer->doc .= "video_attr : ".$video_attr."<br />";*/
 
         if($video_align == "center") {
             $align = "margin: 0 auto;";
@@ -126,7 +112,6 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
                 $renderer->doc .= "Error: The video must be in webm, ogv, or mp4 format.<br />" . $video_urls[$i];
                 return false;
             }
-            //$renderer->doc .= "video_url new : ".$video_urls[$i]."<br />";
         }
 
         if(is_null($video_size) or !substr_count($video_size, 'x')) {

--- a/syntax/video.php
+++ b/syntax/video.php
@@ -124,10 +124,6 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
             }
         }
 
-        /*for($i=0; $i<$nb; ++$i) {
-            $renderer->doc .= $video_urls[$i] . " -> " . $video_url_types[$i] ."<br />";
-        }*/
-
         if(is_null($video_size) or !substr_count($video_size, 'x')) {
             $width  = 640;
             $height = 360;


### PR DESCRIPTION
This patch add the support of multiple video files and format. Here is an example :

<code>
{{ videos:vid.webm|videos:vid.ogv|videos:vid.mp4|320x240|loop }}
</code>

For this, you must have the video in all formats. In this example videos/vid.webm, videos/vid.ogv and videos/vid.mp4
