### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/video.php
+++ b/syntax/video.php
@@ -43,7 +43,7 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('\{\{[^}]*(?:(?:webm)|(?:ogv)|(?:mp4))(?:\|(?:\d{2,4}x\d{2,4})?(?:\|(?:loop)?,?(?:autoplay)?(?:,loop)?)?)? ?\}\}',$mode,'plugin_html5video_video');
     }
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
         $params = substr($match, strlen('{{'), - strlen('}}')); //Strip markup
         if(strpos($params, ' ') === 0) { // Space as first character
             if(substr_compare($params, ' ', -1, 1) === 0) { // Space a front and back = centered
@@ -65,7 +65,7 @@ class syntax_plugin_html5video_video extends DokuWiki_Syntax_Plugin {
         return array(state, explode('|', $params));
     }
 
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
 
         list($state, $params) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
